### PR TITLE
Use http if $INSECURE == true.

### DIFF
--- a/lib/s3-common.sh
+++ b/lib/s3-common.sh
@@ -283,7 +283,7 @@ ${hashedRequest}"
   cmd+=("-H" "Authorization: ${authorizationHeader}")
 
   local protocol="https"
-  if [[ $INSECURE == false ]]; then
+  if [[ $INSECURE == true ]]; then
     protocol="http"
   fi
   cmd+=("${protocol}://${host}${RESOURCE_PATH}")


### PR DESCRIPTION
Currently, requests are defaulting to http, and providing the `--insecure` flag makes the requests use https.

This fixes that, so that the requests default to https, and the `--insecure` flag makes the request use http.