### PR TITLE
Add optional security token to requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Variable               | Description
 `AWS_ACCESS_KEY_ID`    | Default _AWS Access Key ID_
 `AWS_SECRET_ACCESS_KEY`| Default _AWS Secret Access Key_
 `AWS_DEFAULT_REGION`   | Default _AWS S3 Region_
+`AWS_SECURITY_TOKEN`   | Default _AWS Security Token for temporary credentials_
 
 ### Requirements
   - _OpenSSL_

--- a/bin/s3-delete
+++ b/bin/s3-delete
@@ -44,6 +44,7 @@ printUsageAndExitWith() {
   printf "  -k,--key\tAWS Access Key ID. Default to environment variable AWS_ACCESS_KEY_ID\n"
   printf "  -r,--region\tAWS S3 Region. Default to environment variable AWS_DEFAULT_REGION\n"
   printf "  -s,--secret\tFile containing AWS Secret Access Key. If not set, secret will be environment variable AWS_SECRET_ACCESS_KEY\n"
+  printf "  -t,--token\tSecurity token for temporary credentials. If not set, token will be environment variable AWS_SECURITY_TOKEN\n"
   printf "  -v,--verbose\tVerbose output\n"
   printf "     --version\tShow version\n"
   exit $1
@@ -57,6 +58,7 @@ printUsageAndExitWith() {
 #   AWS_ACCESS_KEY_ID     string
 #   AWS_SECRET_ACCESS_KEY string
 #   AWS_REGION            string
+#   AWS_SECURITY_TOKEN    string
 #   RESOURCE_PATH         string
 #   VERBOSE               bool
 #   INSECURE              bool
@@ -67,6 +69,7 @@ parseCommandLine() {
   AWS_REGION=${AWS_DEFAULT_REGION:-""}
   AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-""}
   AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-""}
+  AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN:-""}
   VERBOSE=false
   INSECURE=false
   DEBUG=false
@@ -85,6 +88,7 @@ parseCommandLine() {
       -r|--region)     assertArgument $@; AWS_REGION=$2; shift;;
       -k|--key)        assertArgument $@; AWS_ACCESS_KEY_ID=$2; shift;;
       -s|--secret)     assertArgument $@; secretKeyFile=$2; shift;;
+      -t|--token)      assertArgument $@; AWS_SECURITY_TOKEN=$2; shift;;
       -*)              err "Unknown option $1"
                        printUsageAndExitWith ${INVALID_USAGE_EXIT_CODE};;
       *)               remaining="${remaining} \"${key}\"";;

--- a/bin/s3-get
+++ b/bin/s3-get
@@ -44,6 +44,7 @@ printUsageAndExitWith() {
   printf "  -k,--key\tAWS Access Key ID. Default to environment variable AWS_ACCESS_KEY_ID\n"
   printf "  -r,--region\tAWS S3 Region. Default to environment variable AWS_DEFAULT_REGION\n"
   printf "  -s,--secret\tFile containing AWS Secret Access Key. If not set, secret will be environment variable AWS_SECRET_ACCESS_KEY\n"
+  printf "  -t,--token\tSecurity token for temporary credentials. If not set, token will be environment variable AWS_SECURITY_TOKEN\n"
   printf "  -v,--verbose\tVerbose output\n"
   printf "     --version\tShow version\n"
   exit $1
@@ -57,6 +58,7 @@ printUsageAndExitWith() {
 #   AWS_ACCESS_KEY_ID     string
 #   AWS_SECRET_ACCESS_KEY string
 #   AWS_REGION            string
+#   AWS_SECURITY_TOKEN    string
 #   RESOURCE_PATH         string
 #   VERBOSE               bool
 #   INSECURE              bool
@@ -67,6 +69,7 @@ parseCommandLine() {
   AWS_REGION=${AWS_DEFAULT_REGION:-""}
   AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-""}
   AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-""}
+  AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN:-""}
   VERBOSE=false
   INSECURE=false
   DEBUG=false
@@ -85,6 +88,7 @@ parseCommandLine() {
       -r|--region)     assertArgument $@; AWS_REGION=$2; shift;;
       -k|--key)        assertArgument $@; AWS_ACCESS_KEY_ID=$2; shift;;
       -s|--secret)     assertArgument $@; secretKeyFile=$2; shift;;
+      -t|--token)      assertArgument $@; AWS_SECURITY_TOKEN=$2; shift;;
       -*)              err "Unknown option $1"
                        printUsageAndExitWith ${INVALID_USAGE_EXIT_CODE};;
       *)               remaining="${remaining} \"${key}\"";;

--- a/bin/s3-put
+++ b/bin/s3-put
@@ -46,6 +46,7 @@ printUsageAndExitWith() {
   printf "  -p,--public\tGrant public read on uploaded file\n"
   printf "  -r,--region\tAWS S3 Region. Default to environment variable AWS_DEFAULT_REGION\n"
   printf "  -s,--secret\tFile containing AWS Secret Access Key. If not set, secret will be environment variable AWS_SECRET_ACCESS_KEY\n"
+  printf "  -t,--token\tSecurity token for temporary credentials. If not set, token will be environment variable AWS_SECURITY_TOKEN\n"
   printf "  -T,--upload-file\tPath to file to upload\n"
   printf "  -v,--verbose\tVerbose output\n"
   printf "     --version\tShow version\n"
@@ -61,6 +62,7 @@ printUsageAndExitWith() {
 #   AWS_ACCESS_KEY_ID     string
 #   AWS_SECRET_ACCESS_KEY string
 #   AWS_REGION            string
+#   AWS_SECURITY_TOKEN    string
 #   RESOURCE_PATH         string
 #   FILE_TO_UPLOAD        string
 #   CONTENT_TYPE          string
@@ -75,6 +77,7 @@ parseCommandLine() {
   AWS_REGION=${AWS_DEFAULT_REGION:-""}
   AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-""}
   AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-""}
+  AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN:-""}
   FILE_TO_UPLOAD=
   CONTENT_TYPE=
   PUBLISH=false
@@ -99,6 +102,7 @@ parseCommandLine() {
       -r|--region)        assertArgument $@; AWS_REGION=$2; shift;;
       -k|--key)           assertArgument $@; AWS_ACCESS_KEY_ID=$2; shift;;
       -s|--secret)        assertArgument $@; secretKeyFile=$2; shift;;
+      -t|--token)         assertArgument $@; AWS_SECURITY_TOKEN=$2; shift;;
       -*)                 err "Unknown option $1"
                           printUsageAndExitWith ${INVALID_USAGE_EXIT_CODE};;
       *)                  remaining="${remaining} \"${key}\"";;

--- a/lib/s3-common.sh
+++ b/lib/s3-common.sh
@@ -257,6 +257,12 @@ performRequest() {
   headers+="x-amz-date:${isoTimestamp}"
   headerList+="x-amz-date"
 
+  if [[ -n "${AWS_SECURITY_TOKEN}" ]]; then
+    cmd+=("-H" "x-amz-security-token: ${AWS_SECURITY_TOKEN}")
+    headers+="\nx-amz-security-token:${AWS_SECURITY_TOKEN}"
+    headerList+=";x-amz-security-token"
+  fi
+
   # Generate canonical request
   local canonicalRequest="${METHOD}
 ${RESOURCE_PATH}


### PR DESCRIPTION
When using temporary credentials, a security token is required to be included with the request (as specified [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)). This adds that capability.