### PR TITLE
Fix missing pattern matching operator

### DIFF
--- a/lib/s3-common.sh
+++ b/lib/s3-common.sh
@@ -45,7 +45,7 @@ assertArgument() {
 #   $1 string resource path
 ##
 assertResourcePath() {
-  if [[ $1 = !(/*) ]]; then
+  if [[ $1 =~ !(/*) ]]; then
     err "Resource should start with / e.g. /bucket/file.ext"
     exit $INVALID_USAGE_EXIT_CODE
   fi


### PR DESCRIPTION
The version without the explicit pattern matching operator seems to work on Linux, and on Bash on Windows, but fails with bash on macOS.